### PR TITLE
invoke the API callback with a mocked response upon Error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -110,7 +110,14 @@ function Client (globalRequest) {
     })
 
     httpRequest.on('error', function (e) {
-      console.log('Error: ' + e.message)
+      var response = JSON.parse(JSON.stringify(emptyResponse))
+      response.statusCode = e.statusCode || 500
+      response.body = JSON.stringify({
+        message: e.message,
+        name: e.name,
+        stack: e.stack,
+      })
+      callback(response)
     })
 
     // if thre is a request body, sent it

--- a/test/test.js
+++ b/test/test.js
@@ -169,5 +169,44 @@ describe('Client', function () {
       })
       done()
     })
+
+    it('should consider non-HTTP-200 repsonses to be valid', function (done) {
+      nock(TEST_HOST)
+        .get('/test')
+        .delay(100) // it('should wait for the response before invoking the callback')
+        .reply(503)
+      var requestGet = client.emptyRequest()
+      requestGet.method = 'GET'
+      requestGet.path = '/test'
+      client.API(requestGet, function (response) {
+        assert.equal(response.statusCode, '503', 'response.StatusCode equal 503')
+        assert.equal(response.body, '',
+          'response.body blank')
+        assert.equal(JSON.stringify(response.headers),
+          '{}',
+          'response.headers blank')
+        done()
+      })
+    })
+
+    it('should respond with a mock HTTP 500 response upon Error', function (done) {
+      nock(TEST_HOST)
+        .get('/test')
+        .replyWithError('ERROR')
+      var requestGet = client.emptyRequest()
+      requestGet.method = 'GET'
+      requestGet.path = '/test'
+      client.API(requestGet, function (response) {
+        assert.equal(response.statusCode, '500', 'response.StatusCode equal 500')
+        var body = JSON.parse(response.body)
+        assert.equal(body.message, 'ERROR', 'response.body.message equal ERROR')
+        assert.equal(body.name, Error.name, 'response.body.name equal Error.name')
+        assert.equal(typeof body.stack, 'string', 'response.body.stack is a String')
+        assert.equal(JSON.stringify(response.headers),
+          '{}',
+          'response.headers blank')
+        done()
+      })
+    })
   })
 })


### PR DESCRIPTION
fixes #5 -- using the 'patch' release strategy.  i suggest that you **clone the issue** if the CPS strategy is more desirable in the long-run, since it suggests a 'major' release

the 'patch' strategy was taken to minimize impact and maximize upradeability within the SendGrid Node.js suite of packages.

given an emitted `new Error('MESSAGE')`, the response Object passed to the callback will include
```javascript
{
  statusCode: 500,
  body: {
    message: 'MESSAGE',
    name: 'Error',
    stack: 'Error: MESSAGE\n...',
  },
  headers: {},
}
```
