### PR TITLE
Ability to optionally assign port for requests when calling client API

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -58,6 +58,10 @@ function Client (globalRequest) {
     request.host = endpointRequest.host || globalRequest.host
     request.method = endpointRequest.method
 
+    if (endpointRequest.port) {
+      request.port = endpointRequest.port
+    }
+
     // build URL
     request.path = !isEmpty(endpointRequest.queryParams)
       ? buildPath(endpointRequest.path, endpointRequest.queryParams)


### PR DESCRIPTION
When calling client.API, allow for optional port to be assigned in endpointRequest which is then  used in the buildrequest.

This is to allow for environments that sit behind corporate firewalls or proxies that have strict environments were HTTPs request must have port 443 assigned during request (unlike the current default request which port is empty).

Usage:
```
var Client = require('sendgrid-rest').Client
var client = new Client()
var request = client.emptyRequest()
var param = 'myparam'
request.host = 'api.example.com'
request.method = 'GET'

request.port = '443' // optional port is now used in request build rather then being ignored

request.path = '/your/api/' + param + '/call'
client.API(request, function (response) {
  console.log(response.body)
  console.log(response.headers)
})
```

This would also work the same for the sendgrid-node lib.