### PR TITLE
Adds test to check license end year.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -319,4 +319,19 @@ describe('nodejs-http-client repo', function() {
       throw e;
     }
   }
-});
+})
+
+describe('LICENSE', function() {
+  it('should have correct end year', function(done) {
+    var licenseFile = fs.readFileSync('LICENSE.md', 'utf8')
+    var licenseYearRange = licenseFile.split('\n')[2].split(' ')[2]
+    var endYear = licenseYearRange.split('-')[1]
+    var thisYear = (new Date()).getFullYear()
+
+    if (endYear != thisYear) {
+      assert.fail(thisYear, endYear, "LICENSE end year is not correct")
+    } else {
+      done()
+    }
+  })
+})


### PR DESCRIPTION
Fixes #51 

Please note that added test is failing right now, as `LICENSE.txt` file does not have correct end year. Also this test expects the year in range(i.e. `2016-2017`), but only contains `2016`. Maybe fix after #53 